### PR TITLE
Normalize imports and ordering in app.pl to satisfy linter

### DIFF
--- a/app.pl
+++ b/app.pl
@@ -1,11 +1,11 @@
 #!/usr/bin/env perl
 
-our $VERSION = '0.0.1';
-
 use strict;
 use warnings;
-use English qw( -no_match_vars );
-use Carp    qw(croak);
+use English qw(-no_match_vars);
+use Carp qw(croak);
+
+our $VERSION = '0.0.1';
 
 sub main {
     print 'Hello world!' or croak "Cannot print: $OS_ERROR\n";


### PR DESCRIPTION
### Motivation
- Fix style/linter warnings in `app.pl` by normalizing import spacing and declaration order.
- Ensure the file follows recommended Perl conventions for `use` statements and `our` placement.
- Improve consistency of `use English` and `use Carp` import syntax.

### Description
- Change `use English qw( -no_match_vars );` to `use English qw(-no_match_vars);` to remove extraneous spacing.
- Change `use Carp    qw(croak);` to `use Carp qw(croak);` to normalize spacing.
- Move `our $VERSION` below the `use` statements to align with the style guide.
- Updated `app.pl` accordingly.

### Testing
- Ran `perl -c app.pl` earlier which reported `syntax OK` for the file prior to these edits.
- Attempted to run `perlcritic` but the command was not available in the environment so linter checks were not executed.
- No other automated tests were run against the modified file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eafe30ab8832bbf7b548da8346aad)